### PR TITLE
Clean up persistent network IDs and settings.

### DIFF
--- a/clone-master-clean-up
+++ b/clone-master-clean-up
@@ -188,6 +188,10 @@ for intf in `ls -1 /etc/sysconfig/network/ifcfg-eth*`; do
         rm -rf $intf
     fi
 done
+if [ -d /var/lib/wicked ]; then
+    echo "Clean up persistent network data"
+    rm -rf /var/lib/wicked/*
+fi
 
 echo "Clean up collectd"
 rm -rf /var/lib/collectd/WebYaST/*


### PR DESCRIPTION
Wicked stores a number of files containing unique
IDs and DHCP data in /var/lib/wicked/*.
These files need to be removed for cloning:
if machines with identical settings exist in
the same network multiple times, IP addresses
may change with each renewal (bsc#1139667).

Signed-off-by: Egbert Eich <eich@suse.com>