### PR TITLE
Make package acceptable for oS:Factory

### DIFF
--- a/_service
+++ b/_service
@@ -2,7 +2,8 @@
   <service name="obs_scm" mode="disabled">
     <param name="scm">git</param>
     <param name="url">https://github.com/SUSE/clone-master-clean-up.git</param>
-    <param name="version">HEAD</param>
+    <param name="versionformat">@PARENT_TAG@.@TAG_OFFSET@</param>
+    <param name="revision">master</param>
     <param name="exclude">.git</param>
     <param name="extract">*</param>
   </service>

--- a/clone-master-clean-up.changes
+++ b/clone-master-clean-up.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Wed Aug  7 11:00:14 UTC 2019 - Egbert Eich <eich@suse.com>
 
+- Install README.md and license file, fix build warnings.
 - Fix _service-file:
   * Replace 'HEAD' version by 'master' branch:
     Right now, this project has just one single branch - track

--- a/clone-master-clean-up.changes
+++ b/clone-master-clean-up.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Aug  7 11:00:14 UTC 2019 - Egbert Eich <eich@suse.com>
+
+- Fix _service-file:
+  * Replace 'HEAD' version by 'master' branch:
+    Right now, this project has just one single branch - track
+    this as the release branch.
+  * Add <versionformat>.
+
+-------------------------------------------------------------------
 Fri Aug  2 13:08:25 UTC 2019 - Egbert Eich <eich@suse.com>
 
 - Add _service file to fetch package form git.

--- a/clone-master-clean-up.spec
+++ b/clone-master-clean-up.spec
@@ -26,6 +26,8 @@ Source0:        clone-master-clean-up.sh
 Source1:        clone-master-clean-up.1
 Source2:        sysconfig.clone-master-clean-up
 Source3:        custom_remove.template
+Source10:       LICENSE
+Source11:       README.md
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       systemd sed curl coreutils
 Requires(post): %fillup_prereq
@@ -42,6 +44,7 @@ Clean up a system for cloning preparation by cleaning up usage history and log f
 %prep
 
 %build
+cp %{S:10} %{S:11} .
 
 %install
 mkdir -p %{buildroot}%{_sbindir}
@@ -62,11 +65,12 @@ mkdir -p %{buildroot}/%{_sysconfdir}/%{name}/
 %fillup_only -n clone-master-clean-up
 
 %files
-%defattr(-,root,root)
+%doc %{basename:%{S:11}}
+%license %{basename:%{S:10}}
 %{_sbindir}/*
 %{_mandir}/man1/*
-%config %{_fillupdir}/*
+%{_fillupdir}/*
 %dir %{_datadir}/%{name}
 %dir %{_sysconfdir}/%{name}
-%config %{_datadir}/%{name}/custom_remove.template
+%{_datadir}/%{name}/custom_remove.template
 %ghost %config %{_sysconfdir}/%{name}/custom_remove


### PR DESCRIPTION
These commits fix up some things around the spec file to make the package acceptable to oS:Factory:
1. List all package files in spec file.
2. Install README.md and license file.
3. Fix warnings: remove %config from non-config files.
4. remove defattr - which is deprecated.
There is also a modification to the _service file - this will work only when there is at least one release tag available.
SInce above changes do not implement any functional changes, we may not want to bump the version, though.