### PR TITLE
add fixes for CVE-2021-32000 (bsc#1181050)

### DIFF
--- a/clone-master-clean-up.1
+++ b/clone-master-clean-up.1
@@ -14,7 +14,7 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH clone-master-clean-up "1" "May 2017" "" "Clean-Up For Cloning Preparation"
+.TH clone-master-clean-up "1" "September 2022" "" "Clean-Up For Cloning Preparation"
 .SH NAME
 clone\-master\-clean\-up - Clean up a system for cloning preparation.
 
@@ -77,7 +77,7 @@ The program asks for confirmation before proceeding with cleanup. If you proceed
 .IP \[bu]
 SUSE registration, all software repositories.
 .IP \[bu]
-SSH host keys, user SSH keys, user authorized keys, user shell history.
+SSH host keys, root user SSH keys, root user authorized keys, root user shell history.
 .IP \[bu]
 User mails and user cron jobs.
 .IP \[bu]

--- a/clone-master-clean-up.changes
+++ b/clone-master-clean-up.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug 30 15:02:45 UTC 2022 - abriel@suse.com
+
+- Bump version to 1.7
+- CVE-2021-32000: fix some potentially dangerous file system
+  operations
+  (bsc#1181050)
+
+-------------------------------------------------------------------
 Wed Aug 12 15:44:30 UTC 2020 - abriel@suse.com
 
 - Bump version to 1.6

--- a/clone-master-clean-up.sh
+++ b/clone-master-clean-up.sh
@@ -65,6 +65,17 @@ rm -rf /var/spool/mail/*
 rm -rf /var/spool/cron/{lastrun,tabs}/*
 
 echo "Clean up postfix"
+for i in /var/spool/postfix/{active,corrupt,deferred,hold,maildrop,saved,bounce,defer,flush,incoming,trace}; do
+    # descend following symlink and check if it was symlink, if not, recursively delete entries in this directory. 'rm -rf' doesn't follow symlinks.
+    cd -P $i
+    if [ "$i" = "${pwd}" ]; then
+	info=( $(stat --printf="%u %g" ".") )
+	owner=${info[0]}
+	group=${info[1]}
+	setpriv --clear-groups --reuid $owner --regid $group rm -rf *
+    fi
+done
+
 rm -rf /var/spool/postfix/{active,corrupt,deferred,hold,maildrop,saved,bounce,defer,flush,incoming,trace}/*
 
 echo 'Removing all temporary files'

--- a/clone-master-clean-up.sh
+++ b/clone-master-clean-up.sh
@@ -4,6 +4,7 @@
 # Author: Howard Guo <hguo@suse.com>
 
 set -e
+shopt -s nullglob
 # bsc#1092378
 DROP_IN_FILE=/etc/clone-master-clean-up/custom_remove
 SYSCONF_FILE=/etc/sysconfig/clone-master-clean-up
@@ -22,6 +23,14 @@ echo -e 'The script will delete root SSH keys, log data, and more.\n' \
      'Type YES and enter to proceed.'
 read -r answer
 [ "$answer" != "YES" ] && exit 1
+
+if [ -n "$(echo /home/*/.ssh/* /home/*/.*_history)" ]; then
+    echo -e 'There seem to be populated /home directories on this system\n' \
+	 'Cloning such systems is not recommended.\n' \
+	 'Type YES if you still would like to proceed.'
+    read answer
+    [ "$answer" != "YES" ] && exit 1
+fi
 
 # source config file
 if [ -r "$SYSCONF_FILE" ]; then
@@ -49,7 +58,7 @@ echo "Removing zypper anonymous ID"
 rm -rf /var/lib/zypp/AnonymousUniqueId
 
 echo 'Removing SSH host keys, user SSH keys, authorized keys, and shell history'
-rm -rf /etc/ssh/ssh_host*key* /root/.ssh/* /home/*/.ssh/* /home/*/.*_history &> /dev/null
+rm -rf /etc/ssh/ssh_host*key* /root/.ssh/*  &> /dev/null
 
 echo 'Removing all mails and cron-jobs'
 rm -rf /var/spool/mail/*

--- a/clone-master-clean-up.sh
+++ b/clone-master-clean-up.sh
@@ -16,7 +16,10 @@ trap 'err_exit $LINENO' ERR
 
 [ "$UID" != "0" ] && echo 'Please run this program as root user.' && exit 1
 
-echo 'The script will delete all SSH keys, log data, and more. Type YES and enter to proceed.'
+echo -e 'The script will delete root SSH keys, log data, and more.\n' \
+     'WARNING: This should only be used on a pristine system\n' \
+     'WARNING: with no populated /home directories!\n' \
+     'Type YES and enter to proceed.'
 read -r answer
 [ "$answer" != "YES" ] && exit 1
 
@@ -234,7 +237,7 @@ fi
 rm -rf /tmp/fstab.tmp
 
 echo "Clean up network files (except interfaces using dhcp boot protocol)"
-# additional files like bondig interfaces or vlans can be found in 
+# additional files like bondig interfaces or vlans can be found in
 # /usr/share/clone-master-clean-up/custom_remove.template
 for intf in /etc/sysconfig/network/ifcfg-eth*; do
     bprot=$(grep "^BOOTPROTO=" "$intf" | sed "s/^BOOTPROTO=//")

--- a/clone-master-clean-up.spec
+++ b/clone-master-clean-up.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package clone-master-clean-up
 #
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2022 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           clone-master-clean-up
-Version:        1.6
+Version:        1.7
 Release:        0
 Summary:        Tool to clean up a system for cloning preparation
 License:        GPL-2.0-or-later


### PR DESCRIPTION
Thanks to Egbert for the main part of the fixes related to CVE-2021-32000

And a discussion with Matthias turned out, that we do not need to change the 'find /var/log -type f' sequence as it is already secure (thanks to 'find' and Matthias)