### PR TITLE
fix bug with postfix cleanup

### DIFF
--- a/clone-master-clean-up.sh
+++ b/clone-master-clean-up.sh
@@ -68,7 +68,7 @@ echo "Clean up postfix"
 for i in /var/spool/postfix/{active,corrupt,deferred,hold,maildrop,saved,bounce,defer,flush,incoming,trace}; do
     if [ -d "$i" ]; then
         # descend following symlink and check if it was symlink, if not, recursively delete entries in this directory. 'rm -rf' doesn't follow symlinks.
-        cd -P "$i"
+        test -d "$i" && cd -P "$i"
         [ "$i" != "$PWD" ] && continue
         info=( $(stat --printf="%u %g" ".") )
         owner=${info[0]}


### PR DESCRIPTION
This patch checks if a directory exists for Postfix cleanup before the script attempts to cd there.