### PR TITLE
Bump version to 1.11

### DIFF
--- a/clone-master-clean-up.changes
+++ b/clone-master-clean-up.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb  7 12:26:43 UTC 2023 - Peter Varkoly <varkoly@suse.com>
+
+- Bump version to 1.11
+- clone-master-clean-up fails when /etc/iscsi/initiatorname.iscsi doesn't exist
+  The entire section is wrapped in a test for the existence of this file.
+  (bsc#1207993)
+
+-------------------------------------------------------------------
 Fri Oct 28 11:41:37 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - Bump version to 1.10

--- a/clone-master-clean-up.sh
+++ b/clone-master-clean-up.sh
@@ -290,8 +290,10 @@ if [ -r "$DROP_IN_FILE" ]; then
     done < $DROP_IN_FILE
 fi
 
-echo 'Clean up initiatorname.iscsi'
-sed -i '/^[^#]/d' /etc/iscsi/initiatorname.iscsi
+if [ -e /etc/iscsi/initiatorname.iscsi ]; then
+    echo 'Clean up initiatorname.iscsi'
+    sed -i '/^[^#]/d' /etc/iscsi/initiatorname.iscsi
+fi
 
 echo 'Finished. The system is now sparkling clean. Feel free to shut it down and image it.'
 

--- a/clone-master-clean-up.spec
+++ b/clone-master-clean-up.spec
@@ -17,7 +17,7 @@
 
 
 Name:           clone-master-clean-up
-Version:        1.10
+Version:        1.11
 Release:        0
 Summary:        Tool to clean up a system for cloning preparation
 License:        GPL-2.0-or-later


### PR DESCRIPTION
clone-master-clean-up fails when /etc/iscsi/initiatorname.iscsi doesn't exist
  The entire section is wrapped in a test for the existence of this file.
  (bsc#1207993)
