### PR TITLE
Fix bsc#1229217

### DIFF
--- a/clone-master-clean-up.1
+++ b/clone-master-clean-up.1
@@ -14,12 +14,17 @@
 .\" * GNU General Public License for more details.
 .\" */
 .\" 
-.TH clone-master-clean-up "1" "September 2022" "" "Clean-Up For Cloning Preparation"
+.TH clone-master-clean-up "1" "September 2024" "" "Clean-Up For Cloning Preparation"
 .SH NAME
-clone\-master\-clean\-up - Clean up a system for cloning preparation.
+clone\-master\-clean\-up [OPTIONS] - Clean up a system for cloning preparation.
 
 .SH OPTIONS
-The program does not accept command line options.
+.IP "\fB\-n, \-\-dont\-ask\fR"
+Do not ask any questions. Run the program with default values even it is not recommended. The root password will also be retained.
+.IP "\fb\-f, \-\-dont\-change\-fstab\fR"
+Do not swap UUID and label into device name in fstab.
+.IP "\fb\-h, \-\-help\fR"
+Print a usage message to stdout and exit successfully.
 
 .SH DESCRIPTION
 Clean up a system and delete all usage history to prepare it for being cloned.
@@ -140,4 +145,4 @@ Template for a vendor/customer-specific drop-in file. Defines additional files a
 
 .SH AUTHOR
 .NF
-Howard Guo <hguo@suse.com>, Angela Briel <abriel@suse.com>
+Howard Guo <hguo@suse.com>, Angela Briel <abriel@suse.com>, Peter Varkoly <varkoly@suse.com>

--- a/clone-master-clean-up.changes
+++ b/clone-master-clean-up.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Sat Aug 24 08:34:04 UTC 2024 - Peter Varkoly <varkoly@suse.com>
+
+- clone-master-clean-up modifies fstab from UUID to /dev/sdx. (bsc#1229217)
+  Introduce two command line parameters:
+       -n, --dont-ask suppresses all requests.
+       -f, --dont-change-fstab  Do not swap UUID and label into device name in fstab.
+  Without this parameters it behaves as usual.
+- 1.13 
+
+-------------------------------------------------------------------
 Tue Mar 19 06:28:29 UTC 2024 - Peter Varkoly <varkoly@suse.com>
 
 - Error message about 'journald.conf' (bsc#1221533)

--- a/clone-master-clean-up.sh
+++ b/clone-master-clean-up.sh
@@ -44,9 +44,7 @@ if [ "${DONT_ASK}" != "YES" ]; then
          'Type YES and enter to proceed.'
     read -r answer
     [ "$answer" != "YES" ] && exit 1
-fi
 
-if [ "${DONT_ASK}" != "YES" ]; then
     if [ -n "$(echo /home/*/.ssh/* /home/*/.*_history)" ]; then
         echo -e 'There seem to be populated /home directories on this system\n' \
                 'Cloning such systems is not recommended.\n' \
@@ -261,16 +259,16 @@ if [ "${DONT_CHANGE_FSTAB}" != "YES" ]; then
     while read -r disk remain; do
         case "$disk" in
         UUID=*)
-        uuid=${disk#UUID=}
-        new_disk=$(/usr/sbin/blkid -U "$uuid")
-    ;;
-       LABEL=*)
-       label=${disk#LABEL=}
-       new_disk=$(/usr/sbin/blkid -L "$label")
-    ;;
+            uuid=${disk#UUID=}
+            new_disk=$(/usr/sbin/blkid -U "$uuid")
+        ;;
+        LABEL=*)
+            label=${disk#LABEL=}
+            new_disk=$(/usr/sbin/blkid -L "$label")
+        ;;
         *)
-        new_disk="$disk"
-    ;;
+            new_disk="$disk"
+        ;;
         esac
         echo "$new_disk $remain" >> /tmp/fstab.tmp
     done < /etc/fstab

--- a/clone-master-clean-up.spec
+++ b/clone-master-clean-up.spec
@@ -17,7 +17,7 @@
 
 
 Name:           clone-master-clean-up
-Version:        1.12
+Version:        1.13
 Release:        0
 Summary:        Tool to clean up a system for cloning preparation
 License:        GPL-2.0-or-later


### PR DESCRIPTION
Problems:
1. clone-master-clean-up.sh converts UUIDs and LABELs into device names in /etc/fstab.
2. The script can not be executed unattended.

Introduce two command line parameters:
 -n, --dont-ask           Do not ask any questions. Run the program with default values even it is not recommended. The root password will also be retained.
-f, --dont-change-fstab  Do not swap UUID and label into device name in fstab.